### PR TITLE
Fix multiple kernel argument parsing

### DIFF
--- a/kernel/src/config.cpp
+++ b/kernel/src/config.cpp
@@ -36,6 +36,7 @@ void config::init(const char *cmdline)
 				add_option(kp, vp);
 
 				kp = p + 1;
+				state = 0;
 			}
 			break;
 		}


### PR DESCRIPTION
## Issue
The kernel was only parsing the first command-line argument correctly, ignoring subsequent arguments. This was due to a state machine logic error in the `config::init()` function, where the parser state wasn't being reset after processing each key-value pair.

## Changes
- Modified the `config::init()` function in `kernel/src/config.cpp`
- Added a state reset after processing each key-value pair

## Details
The main change is in the state machine logic:
```cpp
case 1:
  if (p == ' ') {
    p = 0;
    add_option(kp, vp);
    kp = p + 1;
    state = 0; // Reset state to parse next key-value pair
  }
break;
```

from: https://github.com/tspink/stacsos/blob/8ccb0025c6002b0ebcc4e6a451a4d713ee367f4a/kernel/src/config.cpp#L32-L39

## Testing
Tested with multiple kernel arguments:
```
make run kernel-args="sched=rr console-mode=gfx log-level=1"
```
Which results in additional arguments being parsed correctly.

Note that `log-level` arg is specific to my private fork of StACSOS.