### PR TITLE
Fix user-space memory allocator

### DIFF
--- a/user/ulib/src/mem.cpp
+++ b/user/ulib/src/mem.cpp
@@ -32,12 +32,12 @@ struct memory_block {
 
 	void insert()
 	{
-		memory_block **slot = &free_list;
-		while (*slot) {
-			slot = &(*slot)->next;
+		memory_block *slot = free_list;
+		while (slot) {
+			slot = slot->next;
 		}
 
-		*slot = this;
+		slot = this;
 	}
 
 	memory_block *split(size_t size)
@@ -59,6 +59,7 @@ struct memory_block {
 static void *allocate(size_t size)
 {
 	memory_block *candidate_block = free_list;
+		
 
 	while (candidate_block) {
 		if (candidate_block->size >= size) {


### PR DESCRIPTION
### Issue
The user-space memory allocator was broken, and didn't properly set the next memory block. This meant that after a certain amount (roughly 160 bytes) was allocated, the allocator would page fault. 
```	
char* a;
for (int x =0; x<1000; x++){
	console::get().writef("%d\n",x);
	a = new char;
	delete a;
} 
```
For example, this simple program (from [here](https://github.com/jade-robertson/stacsos/blob/main/user/alloc-test/src/main.cpp)) would error out after 160 allocations. This also broke lists, but only once they passed a certain size (see example program [here](https://github.com/jade-robertson/stacsos/blob/main/user/list-test/src/main.cpp)).

### Changes
Fixed how inserting a memory block works so that the next block is properly set. 

### Testing
Tested with the above program, which now no longer page faults as well as a few other programs which work fine now.